### PR TITLE
Remove tracking

### DIFF
--- a/module/bol.js
+++ b/module/bol.js
@@ -81,7 +81,6 @@ function registerUsageCount( registerKey ) {
       game.settings.set(registerKey, "world-key", worldKey )
     }
     // Simple API counter
-    $.ajax(`https://jdr.lahiette.com/fvtt_appcount/count.php?name="${registerKey}"&worldKey="${worldKey}"&version="${game.release.generation}.${game.release.build}"&system="${game.system.id}"&systemversion="${game.system.data.version}"`)
     /* -------------------------------------------- */
   }
 }


### PR DESCRIPTION
It's also generally a bad idea to expose your foundry server to the
public, especially when your players' passwords are very guessable,
for example, when it is their usernames